### PR TITLE
Improve SSH authentication options for connections

### DIFF
--- a/TableGlassKit/Application/AppDependencies.swift
+++ b/TableGlassKit/Application/AppDependencies.swift
@@ -3,17 +3,20 @@ public struct AppDependencies: Sendable {
     public var sshAliasProvider: any SSHConfigAliasProvider
     public var sshKeychainService: any SSHKeychainService
     public var sshTunnelManager: any SSHTunnelManager
+    public var sshAgentService: any SSHAgentService
 
     public init(
         connectionStore: some ConnectionStore,
         sshAliasProvider: some SSHConfigAliasProvider = DefaultSSHConfigAliasProvider(),
         sshKeychainService: some SSHKeychainService = DefaultSSHKeychainService(),
-        sshTunnelManager: some SSHTunnelManager = NoopSSHTunnelManager()
+        sshTunnelManager: some SSHTunnelManager = NoopSSHTunnelManager(),
+        sshAgentService: some SSHAgentService = DefaultSSHAgentService()
     ) {
         self.connectionStore = connectionStore
         self.sshAliasProvider = sshAliasProvider
         self.sshKeychainService = sshKeychainService
         self.sshTunnelManager = sshTunnelManager
+        self.sshAgentService = sshAgentService
     }
 }
 

--- a/TableGlassKit/Connections/ConnectionProfile.swift
+++ b/TableGlassKit/Connections/ConnectionProfile.swift
@@ -8,24 +8,39 @@ public struct ConnectionProfile: Identifiable, Hashable, Sendable {
     }
 
     public struct SSHConfiguration: Hashable, Sendable {
+        public enum AuthenticationMethod: String, CaseIterable, Sendable {
+            case keyFile
+            case usernameAndPassword
+            case sshAgent
+        }
+
         public var isEnabled: Bool
         public var configAlias: String
         public var username: String
+        public var authenticationMethod: AuthenticationMethod
         public var keychainIdentityLabel: String?
         public var keychainIdentityReference: Data?
+        public var keyFilePath: String
+        public var passwordKeychainIdentifier: String?
 
         public init(
             isEnabled: Bool = false,
             configAlias: String = "",
             username: String = "",
+            authenticationMethod: AuthenticationMethod = .keyFile,
             keychainIdentityLabel: String? = nil,
-            keychainIdentityReference: Data? = nil
+            keychainIdentityReference: Data? = nil,
+            keyFilePath: String = "",
+            passwordKeychainIdentifier: String? = nil
         ) {
             self.isEnabled = isEnabled
             self.configAlias = configAlias
             self.username = username
+            self.authenticationMethod = authenticationMethod
             self.keychainIdentityLabel = keychainIdentityLabel
             self.keychainIdentityReference = keychainIdentityReference
+            self.keyFilePath = keyFilePath
+            self.passwordKeychainIdentifier = passwordKeychainIdentifier
         }
     }
 

--- a/TableGlassKit/SSH/SSHAgentService.swift
+++ b/TableGlassKit/SSH/SSHAgentService.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+public protocol SSHAgentService: Sendable {
+    func isAgentReachable() -> Bool
+}
+
+public struct DefaultSSHAgentService: SSHAgentService {
+    private let environment: [String: String]
+    private let fileManager: FileManager
+
+    public init(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default
+    ) {
+        self.environment = environment
+        self.fileManager = fileManager
+    }
+
+    public func isAgentReachable() -> Bool {
+        guard let socketPath = environment["SSH_AUTH_SOCK"], !socketPath.isEmpty else {
+            return false
+        }
+
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: socketPath, isDirectory: &isDirectory), !isDirectory.boolValue else {
+            return false
+        }
+
+        return fileManager.isReadableFile(atPath: socketPath)
+    }
+}


### PR DESCRIPTION
## Summary
- add SSH authentication method controls to the connection editor, including SSH agent status messaging and key file/password inputs
- extend the connection profile and view model to track authentication mode details and refresh SSH agent reachability via a dedicated service
- introduce an SSH agent service and accompanying unit tests covering the new behaviours

## Testing
- swift test *(fails: Could not find Package.swift)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918d5f7f18c832fa48d729c0e148ac3)