### PR TITLE
Add database browser window structure

### DIFF
--- a/TableGlass/Application/AppEnvironment.swift
+++ b/TableGlass/Application/AppEnvironment.swift
@@ -6,9 +6,11 @@ import TableGlassKit
 @MainActor
 final class AppEnvironment: ObservableObject {
     let dependencies: AppDependencies
+    private let browserWindowCoordinator: DatabaseBrowserWindowCoordinator
 
     init(dependencies: AppDependencies) {
         self.dependencies = dependencies
+        self.browserWindowCoordinator = DatabaseBrowserWindowCoordinator()
     }
 
     static func makeDefault() -> AppEnvironment {
@@ -30,5 +32,14 @@ final class AppEnvironment: ObservableObject {
             sshAliasProvider: dependencies.sshAliasProvider,
             sshKeychainService: dependencies.sshKeychainService
         )
+    }
+
+    func makeDatabaseBrowserViewModel() -> DatabaseBrowserViewModel {
+        DatabaseBrowserViewModel()
+    }
+
+    func openStandaloneDatabaseBrowserWindow() {
+        let viewModel = makeDatabaseBrowserViewModel()
+        browserWindowCoordinator.openStandaloneWindow(with: viewModel)
     }
 }

--- a/TableGlass/Application/DatabaseBrowserWindowCoordinator.swift
+++ b/TableGlass/Application/DatabaseBrowserWindowCoordinator.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+#if canImport(AppKit)
+import AppKit
+#endif
+
+@MainActor
+final class DatabaseBrowserWindowCoordinator {
+    #if canImport(AppKit)
+    private var controllers: [NSWindowController] = []
+    #endif
+
+    func openStandaloneWindow(with viewModel: DatabaseBrowserViewModel) {
+        #if canImport(AppKit)
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 960, height: 640),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        let hostingController = NSHostingController(rootView: DatabaseBrowserWindow(viewModel: viewModel))
+        window.title = viewModel.windowTitle
+        window.contentViewController = hostingController
+        let windowController = NSWindowController(window: window)
+        windowController.showWindow(nil)
+        controllers.append(windowController)
+        #else
+        // Intentionally left blank for non-macOS platforms.
+        #endif
+    }
+}

--- a/TableGlass/Application/SceneID.swift
+++ b/TableGlass/Application/SceneID.swift
@@ -1,0 +1,4 @@
+enum SceneID: String {
+    case connectionManagement
+    case databaseBrowser
+}

--- a/TableGlass/Application/UITestArguments.swift
+++ b/TableGlass/Application/UITestArguments.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+enum UITestArguments: String {
+    case databaseBrowser = "--uitest-database-browser"
+}

--- a/TableGlass/ContentView.swift
+++ b/TableGlass/ContentView.swift
@@ -10,6 +10,8 @@ import TableGlassKit
 
 struct ContentView: View {
     @ObservedObject private var viewModel: ConnectionListViewModel
+    @Environment(\.openWindow) private var openWindow
+    @State private var didTriggerUITestBrowserWindow = false
 
     init(viewModel: ConnectionListViewModel) {
         _viewModel = ObservedObject(wrappedValue: viewModel)
@@ -46,6 +48,12 @@ struct ContentView: View {
         }
         .task {
             await viewModel.loadConnections()
+
+            guard !didTriggerUITestBrowserWindow else { return }
+            if ProcessInfo.processInfo.arguments.contains(UITestArguments.databaseBrowser.rawValue) {
+                didTriggerUITestBrowserWindow = true
+                openWindow(id: SceneID.databaseBrowser.rawValue)
+            }
         }
     }
 }

--- a/TableGlass/Features/DatabaseBrowser/DatabaseBrowserModels.swift
+++ b/TableGlass/Features/DatabaseBrowser/DatabaseBrowserModels.swift
@@ -1,0 +1,137 @@
+import Foundation
+import SwiftUI
+
+struct DatabaseBrowserSessionViewState: Identifiable, Hashable {
+    let id: UUID
+    var databaseName: String
+    var status: DatabaseBrowserSessionStatus
+    var isReadOnly: Bool
+    var sidebarSections: [DatabaseBrowserSidebarSection]
+
+    init(
+        id: UUID = UUID(),
+        databaseName: String,
+        status: DatabaseBrowserSessionStatus,
+        isReadOnly: Bool,
+        sidebarSections: [DatabaseBrowserSidebarSection] = DatabaseBrowserSidebarSection.defaults
+    ) {
+        self.id = id
+        self.databaseName = databaseName
+        self.status = status
+        self.isReadOnly = isReadOnly
+        self.sidebarSections = sidebarSections
+    }
+}
+
+enum DatabaseBrowserSessionStatus: String, Hashable, CaseIterable {
+    case connecting
+    case online
+    case readOnly
+    case error
+
+    var description: String {
+        switch self {
+        case .connecting:
+            "Connecting"
+        case .online:
+            "Online"
+        case .readOnly:
+            "Read Only"
+        case .error:
+            "Error"
+        }
+    }
+
+    var indicatorColor: Color {
+        switch self {
+        case .connecting:
+            .yellow
+        case .online:
+            .green
+        case .readOnly:
+            .blue
+        case .error:
+            .red
+        }
+    }
+}
+
+struct DatabaseBrowserSidebarSection: Identifiable, Hashable {
+    let id: UUID
+    var title: String
+    var items: [DatabaseBrowserSidebarItem]
+
+    init(id: UUID = UUID(), title: String, items: [DatabaseBrowserSidebarItem]) {
+        self.id = id
+        self.title = title
+        self.items = items
+    }
+}
+
+struct DatabaseBrowserSidebarItem: Identifiable, Hashable {
+    enum Kind: String {
+        case table
+        case view
+        case storedProcedure
+    }
+
+    let id: UUID
+    var name: String
+    var kind: Kind
+
+    init(id: UUID = UUID(), name: String, kind: Kind) {
+        self.id = id
+        self.name = name
+        self.kind = kind
+    }
+}
+
+extension DatabaseBrowserSidebarSection {
+    static var defaults: [DatabaseBrowserSidebarSection] {
+        [
+            DatabaseBrowserSidebarSection(
+                title: "Tables",
+                items: [
+                    DatabaseBrowserSidebarItem(name: "users", kind: .table),
+                    DatabaseBrowserSidebarItem(name: "orders", kind: .table),
+                    DatabaseBrowserSidebarItem(name: "payments", kind: .table)
+                ]
+            ),
+            DatabaseBrowserSidebarSection(
+                title: "Views",
+                items: [
+                    DatabaseBrowserSidebarItem(name: "active_users", kind: .view),
+                    DatabaseBrowserSidebarItem(name: "order_summary", kind: .view)
+                ]
+            ),
+            DatabaseBrowserSidebarSection(
+                title: "Procedures",
+                items: [
+                    DatabaseBrowserSidebarItem(name: "update_stats", kind: .storedProcedure)
+                ]
+            )
+        ]
+    }
+}
+
+extension DatabaseBrowserSessionViewState {
+    static var previewSessions: [DatabaseBrowserSessionViewState] {
+        [
+            DatabaseBrowserSessionViewState(
+                databaseName: "analytics",
+                status: .connecting,
+                isReadOnly: true
+            ),
+            DatabaseBrowserSessionViewState(
+                databaseName: "production",
+                status: .online,
+                isReadOnly: false
+            )
+        ]
+    }
+
+    func sidebarItem(with identifier: DatabaseBrowserSidebarItem.ID?) -> DatabaseBrowserSidebarItem? {
+        guard let identifier else { return nil }
+        return sidebarSections.flatMap { $0.items }.first(where: { $0.id == identifier })
+    }
+}

--- a/TableGlass/Features/DatabaseBrowser/DatabaseBrowserViewModel.swift
+++ b/TableGlass/Features/DatabaseBrowser/DatabaseBrowserViewModel.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+@MainActor
+final class DatabaseBrowserViewModel: ObservableObject {
+    @Published private(set) var sessions: [DatabaseBrowserSessionViewState]
+    @Published var selectedSessionID: DatabaseBrowserSessionViewState.ID?
+
+    init(sessions: [DatabaseBrowserSessionViewState] = DatabaseBrowserSessionViewState.previewSessions) {
+        if sessions.isEmpty {
+            self.sessions = DatabaseBrowserSessionViewState.previewSessions
+        } else {
+            self.sessions = sessions
+        }
+        selectedSessionID = self.sessions.first?.id
+    }
+
+    func appendSession(named name: String) {
+        let newSession = DatabaseBrowserSessionViewState(
+            databaseName: name,
+            status: .connecting,
+            isReadOnly: true
+        )
+        sessions.append(newSession)
+        selectedSessionID = newSession.id
+    }
+
+    func setReadOnly(_ isReadOnly: Bool, for sessionID: DatabaseBrowserSessionViewState.ID) {
+        guard let index = sessions.firstIndex(where: { $0.id == sessionID }) else { return }
+        sessions[index].isReadOnly = isReadOnly
+    }
+
+    func markStatus(_ status: DatabaseBrowserSessionStatus, for sessionID: DatabaseBrowserSessionViewState.ID) {
+        guard let index = sessions.firstIndex(where: { $0.id == sessionID }) else { return }
+        sessions[index].status = status
+    }
+
+    func removeSession(_ sessionID: DatabaseBrowserSessionViewState.ID) {
+        sessions.removeAll { $0.id == sessionID }
+        if selectedSessionID == sessionID {
+            selectedSessionID = sessions.first?.id
+        }
+    }
+
+    var windowTitle: String {
+        "Database Browser"
+    }
+}

--- a/TableGlass/Features/DatabaseBrowser/DatabaseBrowserWindow.swift
+++ b/TableGlass/Features/DatabaseBrowser/DatabaseBrowserWindow.swift
@@ -1,0 +1,144 @@
+import SwiftUI
+
+struct DatabaseBrowserWindow: View {
+    @StateObject private var viewModel: DatabaseBrowserViewModel
+
+    init(viewModel: DatabaseBrowserViewModel) {
+        _viewModel = StateObject(wrappedValue: viewModel)
+    }
+
+    var body: some View {
+        TabView(selection: $viewModel.selectedSessionID) {
+            ForEach(viewModel.sessions) { session in
+                DatabaseBrowserSessionView(
+                    session: session,
+                    onShowLog: { /* Placeholder for log presentation */ },
+                    onToggleReadOnly: { value in
+                        viewModel.setReadOnly(value, for: session.id)
+                    }
+                )
+                .tag(session.id as DatabaseBrowserSessionViewState.ID?)
+                .tabItem {
+                    Label(session.databaseName, systemImage: "server.rack")
+                }
+            }
+        }
+        .tabViewStyle(.automatic)
+        .accessibilityIdentifier(DatabaseBrowserAccessibility.tabGroup.rawValue)
+    }
+}
+
+private struct DatabaseBrowserSessionView: View {
+    let session: DatabaseBrowserSessionViewState
+    let onShowLog: () -> Void
+    let onToggleReadOnly: (Bool) -> Void
+
+    @State private var selectedSidebarItemID: DatabaseBrowserSidebarItem.ID?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            NavigationSplitView {
+                sidebar
+            } detail: {
+                detailView
+            }
+        }
+        .frame(minWidth: 760, minHeight: 520)
+    }
+
+    private var header: some View {
+        HStack(spacing: 16) {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(session.status.indicatorColor)
+                    .frame(width: 10, height: 10)
+                Text(session.databaseName)
+                    .font(.headline)
+                    .bold()
+                Text(session.status.description)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button("Show Log") {
+                onShowLog()
+            }
+            .buttonStyle(.bordered)
+            .accessibilityIdentifier(DatabaseBrowserAccessibility.showLogButton.rawValue)
+
+            Toggle("Read-Only", isOn: Binding(
+                get: { session.isReadOnly },
+                set: { newValue in
+                    onToggleReadOnly(newValue)
+                }
+            ))
+            .toggleStyle(.switch)
+            .accessibilityIdentifier(DatabaseBrowserAccessibility.readOnlyToggle.rawValue)
+        }
+        .padding(.vertical, 12)
+        .padding(.horizontal, 16)
+        .background(.thickMaterial)
+    }
+
+    private var sidebar: some View {
+        List(selection: $selectedSidebarItemID) {
+            ForEach(session.sidebarSections) { section in
+                Section(section.title) {
+                    ForEach(section.items) { item in
+                        Label(item.name, systemImage: iconName(for: item.kind))
+                            .accessibilityIdentifier(DatabaseBrowserAccessibility.sidebarRow(for: item.name))
+                    }
+                }
+            }
+        }
+        .frame(minWidth: 220)
+    }
+
+    private var detailView: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            if let item = session.sidebarItem(with: selectedSidebarItemID) {
+                Text(item.name)
+                    .font(.title2)
+                    .bold()
+                    .accessibilityIdentifier(DatabaseBrowserAccessibility.detailTitle.rawValue)
+                Text("Detail view placeholder for \(item.kind.rawValue).").foregroundStyle(.secondary)
+            } else {
+                Text("Select an object to view details")
+                    .font(.title3)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .padding()
+        .background(.background)
+    }
+
+    private func iconName(for kind: DatabaseBrowserSidebarItem.Kind) -> String {
+        switch kind {
+        case .table:
+            return "tablecells"
+        case .view:
+            return "eye"
+        case .storedProcedure:
+            return "gear"
+        }
+    }
+}
+
+private enum DatabaseBrowserAccessibility: String {
+    case tabGroup = "databaseBrowser.tabGroup"
+    case showLogButton = "databaseBrowser.showLogButton"
+    case readOnlyToggle = "databaseBrowser.readOnlyToggle"
+    case detailTitle = "databaseBrowser.detailTitle"
+
+    static func sidebarRow(for name: String) -> String {
+        "databaseBrowser.sidebar.\(name)"
+    }
+}
+
+#Preview("Database Browser Window") {
+    DatabaseBrowserWindow(viewModel: DatabaseBrowserViewModel())
+}

--- a/TableGlass/TableGlassApp.swift
+++ b/TableGlass/TableGlassApp.swift
@@ -30,15 +30,15 @@ struct TableGlassApp: App {
         }
 
         connectionManagementWindow
+        databaseBrowserWindow
     }
 
     var commands: some Commands {
         ConnectionManagementCommands()
+        DatabaseBrowserCommands(openStandaloneBrowserWindow: {
+            environment.openStandaloneDatabaseBrowserWindow()
+        })
     }
-}
-
-private enum SceneID: String {
-    case connectionManagement
 }
 
 extension TableGlassApp {
@@ -52,6 +52,17 @@ extension TableGlassApp {
     }
 }
 
+extension TableGlassApp {
+    fileprivate var databaseBrowserWindow: some Scene {
+        WindowGroup("Database Browser", id: SceneID.databaseBrowser.rawValue) {
+            DatabaseBrowserWindow(viewModel: environment.makeDatabaseBrowserViewModel())
+                .environmentObject(environment)
+                .frame(minWidth: 900, minHeight: 600)
+        }
+        .defaultSize(width: 1080, height: 720)
+    }
+}
+
 private struct ConnectionManagementCommands: Commands {
     @Environment(\.openWindow) private var openWindow
 
@@ -61,6 +72,24 @@ private struct ConnectionManagementCommands: Commands {
                 openWindow(id: SceneID.connectionManagement.rawValue)
             }
             .keyboardShortcut("M", modifiers: [.command, .shift])
+        }
+    }
+}
+
+private struct DatabaseBrowserCommands: Commands {
+    @Environment(\.openWindow) private var openWindow
+    let openStandaloneBrowserWindow: () -> Void
+
+    var body: some Commands {
+        CommandMenu("Database Browser") {
+            Button("New Browser Window") {
+                openWindow(id: SceneID.databaseBrowser.rawValue)
+            }
+            .keyboardShortcut("B", modifiers: [.command, .shift])
+
+            Button("New Detached Browser Window") {
+                openStandaloneBrowserWindow()
+            }
         }
     }
 }

--- a/TableGlassUITests/TableGlassUITests.swift
+++ b/TableGlassUITests/TableGlassUITests.swift
@@ -32,6 +32,39 @@ final class TableGlassUITests: XCTestCase {
     }
 
     @MainActor
+    func testDatabaseBrowserTabsRender() throws {
+        let app = XCUIApplication()
+        app.launchArguments.append("--uitest-database-browser")
+        app.launch()
+
+        let tabGroup = app.tabGroups["databaseBrowser.tabGroup"]
+        XCTAssertTrue(tabGroup.waitForExistence(timeout: 2))
+
+        XCTAssertGreaterThan(tabGroup.buttons.count, 1)
+
+        let logButton = app.buttons["databaseBrowser.showLogButton"]
+        XCTAssertTrue(logButton.exists)
+
+        let readOnlyToggle = app.switches["databaseBrowser.readOnlyToggle"]
+        XCTAssertTrue(readOnlyToggle.exists)
+    }
+
+    @MainActor
+    func testDatabaseBrowserSidebarNavigation() throws {
+        let app = XCUIApplication()
+        app.launchArguments.append("--uitest-database-browser")
+        app.launch()
+
+        let usersRow = app.staticTexts["databaseBrowser.sidebar.users"]
+        XCTAssertTrue(usersRow.waitForExistence(timeout: 2))
+        usersRow.click()
+
+        let detailTitle = app.staticTexts["databaseBrowser.detailTitle"]
+        XCTAssertTrue(detailTitle.waitForExistence(timeout: 1))
+        XCTAssertEqual(detailTitle.label, "users")
+    }
+
+    @MainActor
     func testLaunchPerformance() throws {
         // This measures how long it takes to launch your application.
         measure(metrics: [XCTApplicationLaunchMetric()]) {


### PR DESCRIPTION
## Summary
- add the Database Browser window scene with a SwiftUI tab layout, session header, and split view placeholders for schema browsing
- wire the new scene into the app, expose AppKit-based window scaffolding, and surface a launch argument that opens the browser window for UI automation
- expand the UI test target to validate that tabs render and sidebar selection updates the detail view

## Testing
- Not run (not supported in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d9c2bc728832fba4e4e024e521dca)