### PR TITLE
Add a Cmd+P-Style Quick Resource Palette

### DIFF
--- a/TableGlass.xcodeproj/project.pbxproj
+++ b/TableGlass.xcodeproj/project.pbxproj
@@ -11,6 +11,10 @@
 		175FDDA02ED267D40049B9DB /* TableGlassKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 17DE3D1F2EC012860034C244 /* TableGlassKit.framework */; };
 		175FDDA32ED2685B0049B9DB /* TableGlassKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 17DE3D1F2EC012860034C244 /* TableGlassKit.framework */; };
 		175FDDA42ED2685B0049B9DB /* TableGlassKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 17DE3D1F2EC012860034C244 /* TableGlassKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		7EBCB6102F0D4F6A00A1A001 /* QuickResourcePaletteModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EBCB6002F0D4F6A00A1A001 /* QuickResourcePaletteModels.swift */; };
+		7EBCB6112F0D4F6A00A1A001 /* QuickResourcePaletteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EBCB6012F0D4F6A00A1A001 /* QuickResourcePaletteViewModel.swift */; };
+		7EBCB6122F0D4F6A00A1A001 /* QuickResourcePaletteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EBCB6022F0D4F6A00A1A001 /* QuickResourcePaletteView.swift */; };
+		7EBCB6132F0D4F6A00A1A001 /* QuickResourceMatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EBCB6032F0D4F6A00A1A001 /* QuickResourceMatcherTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -63,6 +67,10 @@
 		17DE3CCC2EC012860034C244 /* TableGlassTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TableGlassTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		17DE3CD62EC012860034C244 /* TableGlassUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = TableGlassUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		17DE3D1F2EC012860034C244 /* TableGlassKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TableGlassKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7EBCB6002F0D4F6A00A1A001 /* QuickResourcePaletteModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableGlass/Features/DatabaseBrowser/QuickResourcePaletteModels.swift; sourceTree = SOURCE_ROOT; };
+		7EBCB6012F0D4F6A00A1A001 /* QuickResourcePaletteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableGlass/Features/DatabaseBrowser/QuickResourcePaletteViewModel.swift; sourceTree = SOURCE_ROOT; };
+		7EBCB6022F0D4F6A00A1A001 /* QuickResourcePaletteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableGlass/Features/DatabaseBrowser/QuickResourcePaletteView.swift; sourceTree = SOURCE_ROOT; };
+		7EBCB6032F0D4F6A00A1A001 /* QuickResourceMatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableGlassTests/QuickResourceMatcherTests.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -337,6 +345,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7EBCB6102F0D4F6A00A1A001 /* QuickResourcePaletteModels.swift in Sources */,
+				7EBCB6112F0D4F6A00A1A001 /* QuickResourcePaletteViewModel.swift in Sources */,
+				7EBCB6122F0D4F6A00A1A001 /* QuickResourcePaletteView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -344,6 +355,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7EBCB6132F0D4F6A00A1A001 /* QuickResourceMatcherTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TableGlass.xcodeproj/project.pbxproj
+++ b/TableGlass.xcodeproj/project.pbxproj
@@ -467,8 +467,8 @@
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = TableGlass;
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -706,8 +706,8 @@
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = TableGlass;
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -751,8 +751,8 @@
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = TableGlass;
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
+				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.developer-tools";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/TableGlass/Application/DatabaseBrowserCommands.swift
+++ b/TableGlass/Application/DatabaseBrowserCommands.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct DatabaseBrowserCommandActions {
     let runQuery: @MainActor @Sendable () -> Void
     let showHistory: @MainActor @Sendable () -> Void
+    let showQuickOpen: @MainActor @Sendable () -> Void
 }
 
 private struct DatabaseBrowserCommandActionsKey: FocusedValueKey {
@@ -35,6 +36,12 @@ struct DatabaseBrowserCommands: Commands {
             .disabled(commandActions == nil)
 
             Divider()
+
+            Button("Quick Open Resource") {
+                commandActions?.showQuickOpen()
+            }
+            .keyboardShortcut("P", modifiers: [.command])
+            .disabled(commandActions == nil)
 
             Button("Open Connection Window") {
                 openWindow(id: SceneID.connectionManagement.rawValue)

--- a/TableGlass/Application/DatabaseBrowserWindowCoordinator.swift
+++ b/TableGlass/Application/DatabaseBrowserWindowCoordinator.swift
@@ -35,6 +35,7 @@ final class DatabaseBrowserWindowCoordinator: NSObject {
         }
         let windowController = NSWindowController(window: window)
         windowController.showWindow(nil)
+        window.makeKeyAndOrderFront(nil)
         if ProcessInfo.processInfo.arguments.contains(UITestArguments.databaseBrowser.rawValue) {
             NSApp.activate(ignoringOtherApps: true)
             window.makeKeyAndOrderFront(nil)

--- a/TableGlass/Features/DatabaseBrowser/DatabaseBrowserSessionViewModel.swift
+++ b/TableGlass/Features/DatabaseBrowser/DatabaseBrowserSessionViewModel.swift
@@ -202,8 +202,11 @@ final class DatabaseBrowserSessionViewModel: ObservableObject, Identifiable {
         if quickResourceIndex == nil {
             await refresh()
         } else if let maximumAge, let last = metadataLastUpdated,
-                  Date().timeIntervalSince(last) > maximumAge, !isRefreshing {
-            Task { await self.refresh() }
+                  Date().timeIntervalSince(last) > maximumAge {
+            if isRefreshing {
+                return quickResourceIndex
+            }
+            await refresh()
         }
         return quickResourceIndex
     }

--- a/TableGlass/Features/DatabaseBrowser/DatabaseBrowserSessionViewModel.swift
+++ b/TableGlass/Features/DatabaseBrowser/DatabaseBrowserSessionViewModel.swift
@@ -16,6 +16,7 @@ final class DatabaseBrowserSessionViewModel: ObservableObject, Identifiable {
     @Published private(set) var isRefreshing: Bool = false
     @Published private(set) var isExpandingAll: Bool = false
     @Published private(set) var loadError: String?
+    @Published private(set) var quickResourceIndex: QuickResourceIndex?
     let queryLog: DatabaseQueryLog
     let queryHistory: DatabaseQueryHistory
 
@@ -25,6 +26,8 @@ final class DatabaseBrowserSessionViewModel: ObservableObject, Identifiable {
     private let modeController: (any DatabaseSessionModeControlling)?
     private let tableDataService: any DatabaseTableDataService
     private let logger = Logger(subsystem: "com.tableglass", category: "DatabaseBrowser.SessionMode")
+    private let metadataCacheStaleness: TimeInterval = 60 * 5
+    private var metadataLastUpdated: Date?
 
     init(
         id: UUID = UUID(),
@@ -77,6 +80,17 @@ final class DatabaseBrowserSessionViewModel: ObservableObject, Identifiable {
             treeNodes = Self.buildTree(from: schema)
             selectedNodeID = nil
             loadError = nil
+            let timestamp = Date()
+            let indexTask = Task.detached(priority: .userInitiated) { [schema, id, databaseName] in
+                QuickResourceIndex.from(
+                    schema: schema,
+                    sessionID: id,
+                    sessionName: databaseName,
+                    timestamp: timestamp
+                )
+            }
+            quickResourceIndex = await indexTask.value
+            metadataLastUpdated = timestamp
         } catch {
             treeNodes = []
             selectedNodeID = nil
@@ -182,6 +196,72 @@ final class DatabaseBrowserSessionViewModel: ObservableObject, Identifiable {
 
     func makeTableContentViewModel(pageSize: Int = 50) -> DatabaseTableContentViewModel {
         DatabaseTableContentViewModel(tableDataService: tableDataService, pageSize: pageSize)
+    }
+
+    func cachedResourceIndex(maximumAge: TimeInterval? = nil) async -> QuickResourceIndex? {
+        if quickResourceIndex == nil {
+            await refresh()
+        } else if let maximumAge, let last = metadataLastUpdated,
+                  Date().timeIntervalSince(last) > maximumAge, !isRefreshing {
+            Task { await self.refresh() }
+        }
+        return quickResourceIndex
+    }
+
+    @discardableResult
+    func focusResource(_ resource: QuickResourceItem) async -> Bool {
+        guard resource.sessionID == id else { return false }
+        guard await ensureMetadataLoaded() else { return false }
+
+        guard let catalogNode = treeNodes.first(where: { node in
+            if case .catalog(let name) = node.kind {
+                return name == resource.catalog
+            }
+            return false
+        }) else {
+            return false
+        }
+
+        await expandNodeIfNeeded(catalogNode.id)
+
+        guard let namespaceNode = findNode(
+            with: resource.namespace,
+            in: catalogNode.id,
+            kindMatcher: { kind in
+                if case .namespace(_, let name) = kind {
+                    return name == resource.namespace
+                }
+                return false
+            }
+        ) else {
+            return false
+        }
+
+        await expandNodeIfNeeded(namespaceNode.id)
+
+        guard let objectNode = findNode(
+            with: resource.name,
+            in: namespaceNode.id,
+            kindMatcher: { kind in
+                switch (kind, resource.kind) {
+                case (.table(_, _, let name), .table):
+                    return name == resource.name
+                case (.view(_, _, let name), .view):
+                    return name == resource.name
+                case (.storedProcedure(_, _, let name), .storedProcedure):
+                    return name == resource.name
+                default:
+                    return false
+                }
+            }
+        ) else {
+            return false
+        }
+
+        updateNode(catalogNode.id) { $0.isExpanded = true }
+        updateNode(namespaceNode.id) { $0.isExpanded = true }
+        selectedNodeID = objectNode.id
+        return true
     }
 }
 
@@ -349,6 +429,42 @@ private extension DatabaseBrowserSessionViewModel {
             nodes[index].isExpanded = true
             expand(nodes: &nodes[index].children)
         }
+    }
+}
+
+// MARK: - Quick resource selection helpers
+
+private extension DatabaseBrowserSessionViewModel {
+    func ensureMetadataLoaded() async -> Bool {
+        if treeNodes.isEmpty && !isRefreshing {
+            await refresh()
+        } else if let last = metadataLastUpdated,
+                  Date().timeIntervalSince(last) > metadataCacheStaleness,
+                  !isRefreshing {
+            Task { await self.refresh() }
+        }
+
+        return !treeNodes.isEmpty
+    }
+
+    func expandNodeIfNeeded(_ id: DatabaseObjectTreeNode.ID) async {
+        await loadChildrenIfNeeded(for: id)
+        updateNode(id) { $0.isExpanded = true }
+    }
+
+    func findNode(
+        with title: String,
+        in parentID: DatabaseObjectTreeNode.ID,
+        kindMatcher: (DatabaseObjectTreeNode.Kind) -> Bool
+    ) -> DatabaseObjectTreeNode? {
+        guard let parent = findNode(with: parentID, in: treeNodes) else { return nil }
+        if parent.children.isEmpty, parent.pendingChildren != nil {
+            return nil
+        }
+
+        return parent.children.first(where: { child in
+            child.title == title && kindMatcher(child.kind)
+        })
     }
 }
 

--- a/TableGlass/Features/DatabaseBrowser/DatabaseBrowserViewModel.swift
+++ b/TableGlass/Features/DatabaseBrowser/DatabaseBrowserViewModel.swift
@@ -196,6 +196,22 @@ final class DatabaseBrowserViewModel: ObservableObject {
         "Database Browser"
     }
 
+    func quickResourceIndices(maximumAge: TimeInterval = 60 * 3) async -> [QuickResourceIndex] {
+        var indices: [QuickResourceIndex] = []
+        for session in sessions {
+            if let index = await session.cachedResourceIndex(maximumAge: maximumAge) {
+                indices.append(index)
+            }
+        }
+        return indices
+    }
+
+    func focus(resource: QuickResourceItem) async {
+        guard let session = sessions.first(where: { $0.id == resource.sessionID }) else { return }
+        selectedSessionID = session.id
+        await session.focusResource(resource)
+    }
+
 }
 
 private extension DatabaseAccessMode {

--- a/TableGlass/Features/DatabaseBrowser/DatabaseBrowserWindow.swift
+++ b/TableGlass/Features/DatabaseBrowser/DatabaseBrowserWindow.swift
@@ -7,21 +7,30 @@ import TableGlassKit
 
 struct DatabaseBrowserWindow: View {
     @StateObject private var viewModel: DatabaseBrowserViewModel
+    @StateObject private var quickPaletteViewModel: QuickResourcePaletteViewModel
     private var isBrowserUITest: Bool {
         ProcessInfo.processInfo.arguments.contains(UITestArguments.databaseBrowser.rawValue)
     }
 
     init(viewModel: DatabaseBrowserViewModel) {
         _viewModel = StateObject(wrappedValue: viewModel)
+        _quickPaletteViewModel = StateObject(wrappedValue: QuickResourcePaletteViewModel(browserViewModel: viewModel))
     }
 
     var body: some View {
-        Group {
+        ZStack {
 #if os(macOS)
             if viewModel.sessions.isEmpty {
                 DatabaseBrowserPlaceholderView()
             } else {
-                DatabaseBrowserTabView(viewModel: viewModel)
+                DatabaseBrowserTabView(
+                    viewModel: viewModel,
+                    onShowQuickOpenPalette: {
+                        Task { @MainActor in
+                            quickPaletteViewModel.present()
+                        }
+                    }
+                )
             }
 #else
             if viewModel.sessions.isEmpty {
@@ -33,6 +42,11 @@ struct DatabaseBrowserWindow: View {
                             session: session,
                             onConfirmAccessMode: { mode in
                                 await viewModel.setAccessMode(mode, for: session.id)
+                            },
+                            onShowQuickOpenPalette: {
+                                Task { @MainActor in
+                                    quickPaletteViewModel.present()
+                                }
                             }
                         )
                         .tag(session.id as DatabaseBrowserSessionViewModel.ID?)
@@ -43,11 +57,20 @@ struct DatabaseBrowserWindow: View {
                 }
                 .tabViewStyle(.automatic)
                 .accessibilityIdentifier(DatabaseBrowserAccessibility.tabGroup.rawValue)
-        }
+            }
 #endif
+            quickPaletteOverlay
         }
+        .animation(.easeInOut(duration: 0.12), value: quickPaletteViewModel.isPresented)
         .task {
             await viewModel.bootstrap()
+        }
+        .onChange(of: viewModel.sessions.count) { _, _ in
+            if quickPaletteViewModel.isPresented {
+                Task {
+                    await quickPaletteViewModel.refreshIndices()
+                }
+            }
         }
 #if os(macOS)
         .onAppear {
@@ -58,11 +81,44 @@ struct DatabaseBrowserWindow: View {
 #endif
     }
 
+    @ViewBuilder
+    private var quickPaletteOverlay: some View {
+        if quickPaletteViewModel.isPresented {
+            ZStack {
+                Color.black.opacity(0.22)
+                    .ignoresSafeArea()
+                    .onTapGesture {
+                        quickPaletteViewModel.dismiss()
+                    }
+
+                QuickResourcePaletteView(
+                    viewModel: quickPaletteViewModel,
+                    onSelect: { match in
+                        Task {
+                            await viewModel.focus(resource: match.item)
+                        }
+                        quickPaletteViewModel.dismiss()
+                    },
+                    onDismiss: {
+                        quickPaletteViewModel.dismiss()
+                    }
+                )
+                .frame(maxWidth: 780)
+                .padding(.horizontal, 80)
+                .padding(.vertical, 60)
+                .transition(.move(edge: .top).combined(with: .opacity))
+                .zIndex(1)
+            }
+            .transition(.opacity)
+        }
+    }
+
 }
 
 private struct DatabaseBrowserSessionView: View {
     @ObservedObject var session: DatabaseBrowserSessionViewModel
     let onConfirmAccessMode: @Sendable (DatabaseAccessMode) async -> Void
+    let onShowQuickOpenPalette: @MainActor @Sendable () -> Void
 
     @StateObject private var logViewModel: DatabaseSessionLogViewModel
     @StateObject private var tableContentViewModel: DatabaseTableContentViewModel
@@ -79,10 +135,12 @@ private struct DatabaseBrowserSessionView: View {
 
     init(
         session: DatabaseBrowserSessionViewModel,
-        onConfirmAccessMode: @escaping @Sendable (DatabaseAccessMode) async -> Void
+        onConfirmAccessMode: @escaping @Sendable (DatabaseAccessMode) async -> Void,
+        onShowQuickOpenPalette: @escaping @Sendable () -> Void
     ) {
         _session = ObservedObject(initialValue: session)
         self.onConfirmAccessMode = onConfirmAccessMode
+        self.onShowQuickOpenPalette = onShowQuickOpenPalette
         _logViewModel = StateObject(wrappedValue: DatabaseSessionLogViewModel(
             databaseName: session.databaseName,
             log: session.queryLog
@@ -408,6 +466,9 @@ private struct DatabaseBrowserSessionView: View {
             showHistory: {
                 detailDisplayMode = .results
                 queryEditorViewModel.beginHistorySearch()
+            },
+            showQuickOpen: {
+                onShowQuickOpenPalette()
             }
         )
     }
@@ -745,9 +806,13 @@ private struct DatabaseObjectTreeRow: View {
 #if os(macOS)
 private struct DatabaseBrowserTabView: NSViewRepresentable {
     @ObservedObject var viewModel: DatabaseBrowserViewModel
+    let onShowQuickOpenPalette: @MainActor @Sendable () -> Void
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(viewModel: viewModel)
+        Coordinator(
+            viewModel: viewModel,
+            onShowQuickOpenPalette: onShowQuickOpenPalette
+        )
     }
 
     func makeNSView(context: Context) -> NSTabView {
@@ -775,11 +840,16 @@ private struct DatabaseBrowserTabView: NSViewRepresentable {
     @MainActor
     final class Coordinator: NSObject, NSTabViewDelegate {
         private let viewModel: DatabaseBrowserViewModel
+        private let onShowQuickOpenPalette: @MainActor @Sendable () -> Void
         weak var tabView: NSTabView?
         private var items: [DatabaseBrowserSessionViewModel.ID: NSTabViewItem] = [:]
 
-        init(viewModel: DatabaseBrowserViewModel) {
+        init(
+            viewModel: DatabaseBrowserViewModel,
+            onShowQuickOpenPalette: @escaping @Sendable () -> Void
+        ) {
             self.viewModel = viewModel
+            self.onShowQuickOpenPalette = onShowQuickOpenPalette
         }
 
         func updateTabs(
@@ -866,7 +936,8 @@ private struct DatabaseBrowserTabView: NSViewRepresentable {
                 session: session,
                 onConfirmAccessMode: { mode in
                     await self.viewModel.setAccessMode(mode, for: session.id)
-                }
+                },
+                onShowQuickOpenPalette: onShowQuickOpenPalette
             )
         }
     }

--- a/TableGlass/Features/DatabaseBrowser/DatabaseQueryEditorView.swift
+++ b/TableGlass/Features/DatabaseBrowser/DatabaseQueryEditorView.swift
@@ -173,10 +173,13 @@ private struct HistorySearchOverlay: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 8) {
-                TextField("Search history", text: $viewModel.historySearchQuery)
-                    .textFieldStyle(.roundedBorder)
-                    .focused($isSearchFieldFocused)
-                    .onSubmit(handleAccept)
+                DatabaseSearchTextField(
+                    prompt: "Search history",
+                    text: $viewModel.historySearchQuery,
+                    onSubmit: handleAccept,
+                    autoFocus: true,
+                    focusBinding: $isSearchFieldFocused
+                )
 
                 Button(action: handleAccept) {
                     Label("Use", systemImage: "arrow.down.doc")
@@ -212,7 +215,6 @@ private struct HistorySearchOverlay: View {
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .shadow(radius: 2)
         .onAppear {
-            isSearchFieldFocused = true
             startMonitoringKeys()
         }
         .onDisappear {
@@ -258,6 +260,35 @@ private struct HistorySearchOverlay: View {
         }
         keyMonitor = nil
         #endif
+    }
+}
+
+struct DatabaseSearchTextField: View {
+    let prompt: String
+    @Binding var text: String
+    var onSubmit: (() -> Void)? = nil
+    var autoFocus: Bool = false
+    var focusBinding: FocusState<Bool>.Binding? = nil
+
+    @FocusState private var isFocused: Bool
+
+    private var effectiveFocus: FocusState<Bool>.Binding {
+        focusBinding ?? $isFocused
+    }
+
+    var body: some View {
+        TextField(prompt, text: $text)
+            .textFieldStyle(.roundedBorder)
+            .focused(effectiveFocus)
+            .submitLabel(.search)
+            .onAppear {
+                if autoFocus {
+                    effectiveFocus.wrappedValue = true
+                }
+            }
+            .onSubmit {
+                onSubmit?()
+            }
     }
 }
 

--- a/TableGlass/Features/DatabaseBrowser/QuickResourcePaletteModels.swift
+++ b/TableGlass/Features/DatabaseBrowser/QuickResourcePaletteModels.swift
@@ -1,0 +1,331 @@
+import Foundation
+import TableGlassKit
+
+struct QuickResourceIndex: Sendable {
+    var sessionID: UUID
+    var sessionName: String
+    var items: [QuickResourceItem]
+    var lastUpdated: Date
+}
+
+extension QuickResourceIndex {
+    static func from(
+        schema: DatabaseSchema,
+        sessionID: UUID,
+        sessionName: String,
+        timestamp: Date = Date()
+    ) -> QuickResourceIndex {
+        let items = schema.catalogs.flatMap { catalog in
+            catalog.namespaces.flatMap { namespace in
+                tablesAndViews(
+                    in: namespace,
+                    catalogName: catalog.name,
+                    sessionID: sessionID,
+                    sessionName: sessionName
+                ) + storedProcedures(
+                    in: namespace,
+                    catalogName: catalog.name,
+                    sessionID: sessionID,
+                    sessionName: sessionName
+                )
+            }
+        }
+
+        return QuickResourceIndex(
+            sessionID: sessionID,
+            sessionName: sessionName,
+            items: items,
+            lastUpdated: timestamp
+        )
+    }
+
+    private static func tablesAndViews(
+        in namespace: DatabaseNamespace,
+        catalogName: String,
+        sessionID: UUID,
+        sessionName: String
+    ) -> [QuickResourceItem] {
+        let tables = namespace.tables.map {
+            QuickResourceItem(
+                sessionID: sessionID,
+                sessionName: sessionName,
+                catalog: catalogName,
+                namespace: namespace.name,
+                name: $0.name,
+                kind: .table
+            )
+        }
+
+        let views = namespace.views.map {
+            QuickResourceItem(
+                sessionID: sessionID,
+                sessionName: sessionName,
+                catalog: catalogName,
+                namespace: namespace.name,
+                name: $0.name,
+                kind: .view
+            )
+        }
+
+        return tables + views
+    }
+
+    private static func storedProcedures(
+        in namespace: DatabaseNamespace,
+        catalogName: String,
+        sessionID: UUID,
+        sessionName: String
+    ) -> [QuickResourceItem] {
+        namespace.procedures.map {
+            QuickResourceItem(
+                sessionID: sessionID,
+                sessionName: sessionName,
+                catalog: catalogName,
+                namespace: namespace.name,
+                name: $0.name,
+                kind: .storedProcedure
+            )
+        }
+    }
+}
+
+struct QuickResourceItem: Identifiable, Hashable, Sendable {
+    let id: String
+    let sessionID: UUID
+    let sessionName: String
+    let catalog: String
+    let namespace: String
+    let name: String
+    let kind: QuickResourceKind
+    let searchableText: String
+    let searchableComponents: [String]
+
+    init(
+        id: String? = nil,
+        sessionID: UUID,
+        sessionName: String,
+        catalog: String,
+        namespace: String,
+        name: String,
+        kind: QuickResourceKind
+    ) {
+        self.sessionID = sessionID
+        self.sessionName = sessionName
+        self.catalog = catalog
+        self.namespace = namespace
+        self.name = name
+        self.kind = kind
+        self.id = id ?? "\(sessionID.uuidString)::\(kind.rawValue)::\(catalog).\(namespace).\(name)"
+
+        let path = "\(catalog).\(namespace).\(name)"
+        let components = [sessionName, catalog, namespace, name, kind.rawValue]
+        self.searchableComponents = components.map { $0.lowercased() }
+        self.searchableText = (components + [path]).joined(separator: " ").lowercased()
+    }
+
+    var pathDescription: String {
+        "\(catalog).\(namespace).\(name)"
+    }
+}
+
+enum QuickResourceKind: String, CaseIterable, Sendable {
+    case table
+    case view
+    case storedProcedure
+
+    var displayName: String {
+        switch self {
+        case .table:
+            return "Table"
+        case .view:
+            return "View"
+        case .storedProcedure:
+            return "Stored Procedure"
+        }
+    }
+
+    var systemImageName: String {
+        switch self {
+        case .table:
+            return "tablecells"
+        case .view:
+            return "eye"
+        case .storedProcedure:
+            return "gearshape"
+        }
+    }
+
+    var bias: Int {
+        switch self {
+        case .table:
+            return 0
+        case .view:
+            return 10
+        case .storedProcedure:
+            return 14
+        }
+    }
+}
+
+struct QuickResourceMatch: Identifiable, Hashable, Sendable {
+    let id: String
+    let item: QuickResourceItem
+    let score: QuickResourceScore
+}
+
+struct QuickResourceScore: Comparable, Hashable, Sendable {
+    let alignmentPenalty: Int
+    let prefixBonus: Int
+    let wordBonus: Int
+    let lengthPenalty: Int
+    let kindBias: Int
+
+    var sortValue: Int {
+        alignmentPenalty
+            + lengthPenalty
+            + kindBias
+            - prefixBonus
+            - wordBonus
+    }
+
+    static func < (lhs: QuickResourceScore, rhs: QuickResourceScore) -> Bool {
+        lhs.sortValue < rhs.sortValue
+    }
+}
+
+enum QuickResourceMatcher {
+    static func rankedMatches(
+        query: String,
+        in index: QuickResourceIndex,
+        scope: QuickResourceKind? = nil,
+        limit: Int = 50
+    ) -> [QuickResourceMatch] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalized = trimmed.lowercased()
+
+        let candidates = index.items.filter { item in
+            guard scope == nil || scope == item.kind else { return false }
+            guard !normalized.isEmpty else { return true }
+            return item.searchableText.contains(normalized)
+        }
+
+        guard !normalized.isEmpty else {
+            let matches = candidates.map { item in
+                QuickResourceMatch(
+                    id: item.id,
+                    item: item,
+                    score: QuickResourceScore(
+                        alignmentPenalty: 0,
+                        prefixBonus: 0,
+                        wordBonus: 0,
+                        lengthPenalty: lengthPenalty(for: item),
+                        kindBias: item.kind.bias
+                    )
+                )
+            }
+
+            return sortMatches(matches)
+                .prefix(limit)
+                .map { $0 }
+        }
+
+        let matches = candidates.compactMap { item in
+            score(normalizedQuery: normalized, item: item)
+        }
+
+        return sortMatches(matches.map(\.match))
+            .prefix(limit)
+            .map { $0 }
+    }
+}
+
+private extension QuickResourceMatcher {
+    static func score(normalizedQuery: String, item: QuickResourceItem) -> (match: QuickResourceMatch, score: QuickResourceScore)? {
+        let tokens = item.name
+            .split { $0 == "_" || $0 == "." }
+            .map { String($0).lowercased() }
+
+        guard let alignment = bestAlignment(for: normalizedQuery, item: item, tokens: tokens) else {
+            return nil
+        }
+
+        let prefixBonus = item.searchableText.hasPrefix(normalizedQuery) ? 30 : 0
+        let wordBonus = wordMatchBonus(query: normalizedQuery, components: item.searchableComponents + tokens)
+        let score = QuickResourceScore(
+            alignmentPenalty: alignment,
+            prefixBonus: prefixBonus,
+            wordBonus: wordBonus,
+            lengthPenalty: lengthPenalty(for: item),
+            kindBias: item.kind.bias
+        )
+
+        return (
+            QuickResourceMatch(id: item.id, item: item, score: score),
+            score
+        )
+    }
+
+    static func alignmentPenalty(for query: String, in target: String) -> Int? {
+        var currentIndex = target.startIndex
+        var penalty = 0
+
+        for character in query {
+            guard let foundIndex = target[currentIndex...].firstIndex(of: character) else {
+                return nil
+            }
+
+            penalty += target.distance(from: currentIndex, to: foundIndex)
+            currentIndex = target.index(after: foundIndex)
+        }
+
+        return penalty
+    }
+
+    static func bestAlignment(for query: String, item: QuickResourceItem, tokens: [String]) -> Int? {
+        let targets = [
+            item.name.lowercased(),
+            item.pathDescription.lowercased(),
+            item.searchableText
+        ] + tokens
+
+        return targets.compactMap { alignmentPenalty(for: query, in: $0) }.min()
+    }
+
+    static func wordMatchBonus(query: String, components: [String]) -> Int {
+        if components.contains(query) {
+            return 40
+        }
+
+        if components.contains(where: { $0.hasPrefix(query) }) {
+            return 20
+        }
+
+        return 0
+    }
+
+    static func lengthPenalty(for item: QuickResourceItem) -> Int {
+        max(0, item.searchableText.count / 12)
+    }
+
+    static func sortMatches(_ matches: [QuickResourceMatch]) -> [QuickResourceMatch] {
+        matches.sorted { lhs, rhs in
+            if lhs.score != rhs.score {
+                return lhs.score < rhs.score
+            }
+
+            if lhs.item.sessionName.caseInsensitiveCompare(rhs.item.sessionName) != .orderedSame {
+                return lhs.item.sessionName.lowercased() < rhs.item.sessionName.lowercased()
+            }
+
+            if lhs.item.pathDescription.caseInsensitiveCompare(rhs.item.pathDescription) != .orderedSame {
+                return lhs.item.pathDescription.lowercased() < rhs.item.pathDescription.lowercased()
+            }
+
+            if lhs.item.kind != rhs.item.kind {
+                return lhs.item.kind.rawValue < rhs.item.kind.rawValue
+            }
+
+            return lhs.item.id < rhs.item.id
+        }
+    }
+}

--- a/TableGlass/Features/DatabaseBrowser/QuickResourcePaletteView.swift
+++ b/TableGlass/Features/DatabaseBrowser/QuickResourcePaletteView.swift
@@ -1,0 +1,160 @@
+import SwiftUI
+
+struct QuickResourcePaletteView: View {
+    @ObservedObject var viewModel: QuickResourcePaletteViewModel
+    let onSelect: (QuickResourceMatch) -> Void
+    let onDismiss: () -> Void
+
+    @State private var selection: QuickResourceMatch.ID?
+    @FocusState private var isSearchFieldFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 12) {
+            header
+            searchBar
+            scopePicker
+            resultsList
+            footer
+        }
+        .frame(maxWidth: 720, maxHeight: 520, alignment: .topLeading)
+        .padding(16)
+        .background(.regularMaterial)
+        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .shadow(radius: 12)
+        .onChange(of: viewModel.searchText) { _, _ in
+            viewModel.scheduleSearch()
+        }
+        .onChange(of: viewModel.selectedScope) { _, _ in
+            viewModel.handleScopeChange()
+        }
+        .onAppear {
+            viewModel.scheduleSearch()
+            isSearchFieldFocused = true
+        }
+    }
+
+    private var header: some View {
+        HStack(spacing: 10) {
+            Label("Quick Open", systemImage: "command")
+                .font(.headline)
+            Spacer()
+            if viewModel.isRefreshingMetadata {
+                ProgressView()
+                    .controlSize(.small)
+                    .accessibilityLabel("Refreshing metadata")
+            } else if let timestamp = viewModel.lastUpdated {
+                Text("Updated \(timestamp.formatted(.relative(presentation: .numeric)))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Button {
+                onDismiss()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+            }
+            .buttonStyle(.plain)
+            .keyboardShortcut(.cancelAction)
+        }
+    }
+
+    private var searchBar: some View {
+        DatabaseSearchTextField(
+            prompt: "Search tables, views, or procedures",
+            text: $viewModel.searchText,
+            onSubmit: submitFirstMatch,
+            autoFocus: true,
+            focusBinding: $isSearchFieldFocused
+        )
+    }
+
+    private var scopePicker: some View {
+        Picker("Scope", selection: $viewModel.selectedScope) {
+            Text("All").tag(QuickResourceKind?.none)
+            ForEach(QuickResourceKind.allCases, id: \.self) { scope in
+                Text(scope.displayName).tag(Optional(scope))
+            }
+        }
+        .pickerStyle(.segmented)
+    }
+
+    private var resultsList: some View {
+        List(selection: $selection) {
+            ForEach(viewModel.matches) { match in
+                Button {
+                    selection = match.id
+                    onSelect(match)
+                } label: {
+                    QuickResourceRow(match: match)
+                }
+                .buttonStyle(.plain)
+                .tag(match.id)
+            }
+        }
+        .listStyle(.inset)
+        .overlay {
+            if viewModel.isIndexEmpty {
+                ContentUnavailableView(
+                    "No metadata yet",
+                    systemImage: "shippingbox",
+                    description: Text("Connect to a database or wait for metadata to finish loading.")
+                )
+            } else if viewModel.matches.isEmpty {
+                ContentUnavailableView(
+                    "No matches",
+                    systemImage: "doc.text.magnifyingglass",
+                    description: Text("Try a different query or scope.")
+                )
+            }
+        }
+    }
+
+    private var footer: some View {
+        HStack(spacing: 12) {
+            Label("⌘P to open, Enter to focus selection, Esc to close", systemImage: "keyboard")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Spacer()
+            if let scope = viewModel.selectedScope {
+                Text(scope.displayName)
+                    .font(.caption)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Color.accentColor.opacity(0.12))
+                    .clipShape(Capsule())
+            }
+        }
+    }
+}
+
+private struct QuickResourceRow: View {
+    let match: QuickResourceMatch
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: match.item.kind.systemImageName)
+                .foregroundStyle(.secondary)
+                .frame(width: 18)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(verbatim: match.item.name)
+                    .font(.headline)
+                Text("\(match.item.catalog).\(match.item.namespace)")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Text(match.item.sessionName)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 6)
+        .contentShape(Rectangle())
+    }
+}
+
+private extension QuickResourcePaletteView {
+    func submitFirstMatch() {
+        guard let first = viewModel.matches.first else { return }
+        selection = first.id
+        onSelect(first)
+    }
+}

--- a/TableGlass/Features/DatabaseBrowser/QuickResourcePaletteViewModel.swift
+++ b/TableGlass/Features/DatabaseBrowser/QuickResourcePaletteViewModel.swift
@@ -1,0 +1,101 @@
+import Combine
+import Foundation
+
+@MainActor
+final class QuickResourcePaletteViewModel: ObservableObject {
+    @Published var isPresented: Bool = false
+    @Published var searchText: String = ""
+    @Published var selectedScope: QuickResourceKind?
+    @Published private(set) var matches: [QuickResourceMatch] = []
+    @Published private(set) var isRefreshingMetadata: Bool = false
+    @Published private(set) var lastUpdated: Date?
+    @Published private(set) var isIndexEmpty: Bool = false
+
+    private let browserViewModel: DatabaseBrowserViewModel
+    private var indices: [UUID: QuickResourceIndex] = [:]
+    private var searchTask: Task<Void, Never>?
+    private var followUpRefreshTask: Task<Void, Never>?
+    private let metadataMaximumAge: TimeInterval = 60 * 3
+    private let resultLimit = 60
+
+    init(browserViewModel: DatabaseBrowserViewModel) {
+        self.browserViewModel = browserViewModel
+    }
+
+    func present() {
+        if isPresented {
+            Task { await refreshIndices() }
+            return
+        }
+        isPresented = true
+        searchText = ""
+        scheduleSearch()
+        Task { await refreshIndices() }
+    }
+
+    func dismiss() {
+        isPresented = false
+        matches = []
+        followUpRefreshTask?.cancel()
+        searchTask?.cancel()
+    }
+
+    func refreshIndices() async {
+        isRefreshingMetadata = true
+        let fetched = await browserViewModel.quickResourceIndices(maximumAge: metadataMaximumAge)
+        indices = Dictionary(uniqueKeysWithValues: fetched.map { ($0.sessionID, $0) })
+        lastUpdated = fetched.map(\.lastUpdated).max()
+        isIndexEmpty = fetched.flatMap(\.items).isEmpty
+        let sessionRefreshing = browserViewModel.sessions.contains { $0.isRefreshing }
+        isRefreshingMetadata = sessionRefreshing
+        scheduleFollowUpRefreshIfNeeded(isRefreshing: sessionRefreshing)
+        await MainActor.run {
+            updateResults()
+        }
+    }
+
+    func scheduleSearch() {
+        searchTask?.cancel()
+        let currentQuery = searchText
+        searchTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 90_000_000)
+            guard let self else { return }
+            await MainActor.run {
+                if self.searchText == currentQuery {
+                    self.updateResults()
+                }
+            }
+        }
+    }
+
+    func handleScopeChange() {
+        updateResults()
+    }
+
+    private func scheduleFollowUpRefreshIfNeeded(isRefreshing: Bool) {
+        followUpRefreshTask?.cancel()
+        guard isRefreshing, isPresented else { return }
+
+        followUpRefreshTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 400_000_000)
+            guard let self, self.isPresented else { return }
+            await self.refreshIndices()
+        }
+    }
+
+    private func updateResults() {
+        let mergedItems = indices.values.flatMap(\.items)
+        let combinedIndex = QuickResourceIndex(
+            sessionID: UUID(),
+            sessionName: "combined",
+            items: mergedItems,
+            lastUpdated: lastUpdated ?? Date()
+        )
+        matches = QuickResourceMatcher.rankedMatches(
+            query: searchText,
+            in: combinedIndex,
+            scope: selectedScope,
+            limit: resultLimit
+        )
+    }
+}

--- a/TableGlassTests/QuickResourceMatcherTests.swift
+++ b/TableGlassTests/QuickResourceMatcherTests.swift
@@ -1,0 +1,127 @@
+import Foundation
+import Testing
+
+@testable import TableGlass
+
+struct QuickResourceMatcherTests {
+    private let sessionID = UUID(uuidString: "00000000-0000-4000-8000-000000000001")!
+
+    @Test
+    func ranksTightMatchesFirst() throws {
+        let index = QuickResourceIndex(
+            sessionID: sessionID,
+            sessionName: "analytics",
+            items: [
+                QuickResourceItem(
+                    sessionID: sessionID,
+                    sessionName: "analytics",
+                    catalog: "main",
+                    namespace: "public",
+                    name: "orders",
+                    kind: .table
+                ),
+                QuickResourceItem(
+                    sessionID: sessionID,
+                    sessionName: "analytics",
+                    catalog: "main",
+                    namespace: "sales",
+                    name: "customer_orders",
+                    kind: .table
+                ),
+                QuickResourceItem(
+                    sessionID: sessionID,
+                    sessionName: "analytics",
+                    catalog: "analytics",
+                    namespace: "derived",
+                    name: "orders_view",
+                    kind: .view
+                ),
+            ],
+            lastUpdated: Date()
+        )
+
+        let matches = QuickResourceMatcher.rankedMatches(query: "ord", in: index)
+
+        #expect(matches.map(\.item.name).prefix(3) == ["orders", "customer_orders", "orders_view"])
+        #expect(matches.first?.score.sortValue ?? .max < matches.last?.score.sortValue ?? .max)
+    }
+
+    @Test
+    func filtersByKindScope() throws {
+        let index = QuickResourceIndex(
+            sessionID: sessionID,
+            sessionName: "analytics",
+            items: [
+                QuickResourceItem(
+                    sessionID: sessionID,
+                    sessionName: "analytics",
+                    catalog: "main",
+                    namespace: "public",
+                    name: "orders",
+                    kind: .table
+                ),
+                QuickResourceItem(
+                    sessionID: sessionID,
+                    sessionName: "analytics",
+                    catalog: "main",
+                    namespace: "public",
+                    name: "orders_v",
+                    kind: .view
+                ),
+                QuickResourceItem(
+                    sessionID: sessionID,
+                    sessionName: "analytics",
+                    catalog: "main",
+                    namespace: "public",
+                    name: "orders_proc",
+                    kind: .storedProcedure
+                ),
+            ],
+            lastUpdated: Date()
+        )
+
+        let matches = QuickResourceMatcher.rankedMatches(
+            query: "orders",
+            in: index,
+            scope: .view
+        )
+
+        #expect(matches.count == 1)
+        #expect(matches.first?.item.kind == .view)
+        #expect(matches.first?.item.name == "orders_v")
+    }
+
+    @Test
+    func appliesStableOrderingForTies() throws {
+        let index = QuickResourceIndex(
+            sessionID: sessionID,
+            sessionName: "analytics",
+            items: [
+                QuickResourceItem(
+                    id: "a",
+                    sessionID: sessionID,
+                    sessionName: "analytics",
+                    catalog: "main",
+                    namespace: "public",
+                    name: "orders_2023",
+                    kind: .table
+                ),
+                QuickResourceItem(
+                    id: "b",
+                    sessionID: sessionID,
+                    sessionName: "analytics",
+                    catalog: "archive",
+                    namespace: "public",
+                    name: "orders_2023",
+                    kind: .table
+                ),
+            ],
+            lastUpdated: Date()
+        )
+
+        let matches = QuickResourceMatcher.rankedMatches(query: "orders_2023", in: index)
+
+        #expect(matches.count == 2)
+        #expect(matches.map(\.item.catalog) == ["archive", "main"])
+    }
+}


### PR DESCRIPTION
## Background
- Navigating to database resources is slow today, especially in large schemas with thousands of tables
- Users expect a VS Code-like `cmd+p` experience in TableGlass

## Proposed Solution
1. Introduce a quick palette that appears on `⌘P`, allowing fuzzy search across tables, views, materialized views, functions, etc.
2. Cache the most recent metadata locally and refresh it in the background to keep the palette responsive without hitting the server on every keystroke.
3. Support fuzzy matching plus category filters (table, view, …); selecting a hit should focus the corresponding tab/detail view.
4. Build the palette UI with SwiftUI `.searchable` and a custom list, providing accessibility labels so VoiceOver can read results.

## Acceptance Criteria
- Pressing `⌘P` opens an overlay, and cached searches over 10k resources render results within 150 ms.
- Choosing a table from the palette focuses that table inside the Database Browser.
- When remote metadata is stale, a background refresh runs automatically without blocking the UI.
- Unit tests cover the fuzzy scoring logic to ensure deterministic ranking.
